### PR TITLE
Add tap tests for two phase commits.

### DIFF
--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -14,7 +14,7 @@ PG_CPPFLAGS = -I$(libpq_srcdir)
 SHLIB_LINK_INTERNAL = $(libpq)
 
 EXTENSION = postgres_fdw
-DATA = postgres_fdw--1.0.sql postgres_fdw--1.0--1.1.sql
+DATA = postgres_fdw--1.0.sql postgres_fdw--1.0--1.1.sql postgres_fdw--1.1--1.2.sql
 
 REGRESS = postgres_fdw
 

--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -18,6 +18,8 @@ DATA = postgres_fdw--1.0.sql postgres_fdw--1.0--1.1.sql postgres_fdw--1.1--1.2.s
 
 REGRESS = postgres_fdw
 
+TAP_TESTS = 1
+
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/contrib/postgres_fdw/connection.c
+++ b/contrib/postgres_fdw/connection.c
@@ -1680,10 +1680,10 @@ pgfdw_prepare_xacts(void)
 		entry->fxid = GetTopFullTransactionId();
 
 		snprintf(sql, sizeof(sql),
-				 "PREPARE TRANSACTION 'pgfdw_%s_%lu_%u'",
-				 (*cluster_name == '\0') ? "null" : cluster_name,
+				 "PREPARE TRANSACTION 'pgfdw_%lu_%u_%s'",
 				 U64FromFullTransactionId(entry->fxid),
-				 (Oid) entry->key);
+				 (Oid) entry->key,
+				 (*cluster_name == '\0') ? "null" : cluster_name);
 
 		entry->changing_xact_state = true;
 		do_sql_command(entry->conn, sql);
@@ -1701,10 +1701,10 @@ pgfdw_commit_prepared(ConnCacheEntry *entry)
 		return false;
 
 	snprintf(sql, sizeof(sql),
-			 "COMMIT PREPARED 'pgfdw_%s_%lu_%u'",
-			 (*cluster_name == '\0') ? "null" : cluster_name,
+			 "COMMIT PREPARED 'pgfdw_%lu_%u_%s'",
 			 U64FromFullTransactionId(entry->fxid),
-			 (Oid) entry->key);
+			 (Oid) entry->key,
+			 (*cluster_name == '\0') ? "null" : cluster_name);
 
 	entry->changing_xact_state = true;
 	success = pgfdw_exec_cleanup_query(entry->conn, sql, false);
@@ -1733,10 +1733,10 @@ pgfdw_rollback_prepared(ConnCacheEntry *entry)
 		return false;
 
 	snprintf(sql, sizeof(sql),
-			 "ROLLBACK PREPARED 'pgfdw_%s_%lu_%u'",
-			 (*cluster_name == '\0') ? "null" : cluster_name,
+			 "ROLLBACK PREPARED 'pgfdw_%lu_%u_%s'",
 			 U64FromFullTransactionId(entry->fxid),
-			 (Oid) entry->key);
+			 (Oid) entry->key,
+			 (*cluster_name == '\0') ? "null" : cluster_name);
 	pgfdw_abort_cleanup(entry, sql, true);
 
 	return true;

--- a/contrib/postgres_fdw/connection.c
+++ b/contrib/postgres_fdw/connection.c
@@ -25,6 +25,7 @@
 #include "storage/latch.h"
 #include "utils/builtins.h"
 #include "utils/datetime.h"
+#include "utils/guc.h"
 #include "utils/hsearch.h"
 #include "utils/inval.h"
 #include "utils/memutils.h"
@@ -55,6 +56,7 @@ typedef struct ConnCacheEntry
 	/* Remaining fields are invalid when conn is NULL: */
 	int			xact_depth;		/* 0 = no xact open, 1 = main xact open, 2 =
 								 * one level of subxact open, etc */
+	FullTransactionId fxid;
 	bool		have_prep_stmt; /* have we prepared any stmts in this xact? */
 	bool		have_error;		/* have any subxacts aborted in this xact? */
 	bool		changing_xact_state;	/* xact state change in process */
@@ -109,6 +111,9 @@ static void pgfdw_abort_cleanup(ConnCacheEntry *entry, const char *sql,
 								bool toplevel);
 static bool UserMappingPasswordRequired(UserMapping *user);
 static bool disconnect_cached_connections(Oid serverid);
+static void pgfdw_prepare_xacts(void);
+static bool pgfdw_commit_prepared(ConnCacheEntry *entry);
+static bool pgfdw_rollback_prepared(ConnCacheEntry *entry);
 
 /*
  * Get a PGconn which can be used to execute queries on the remote PostgreSQL
@@ -293,6 +298,7 @@ make_new_connection(ConnCacheEntry *entry, UserMapping *user)
 
 	/* Reset all transient state fields, to be sure all are clean */
 	entry->xact_depth = 0;
+	entry->fxid = InvalidFullTransactionId;
 	entry->have_prep_stmt = false;
 	entry->have_error = false;
 	entry->changing_xact_state = false;
@@ -856,6 +862,14 @@ pgfdw_xact_callback(XactEvent event, void *arg)
 	if (!xact_got_connection)
 		return;
 
+	if (pgfdw_two_phase_commit &&
+		(event == XACT_EVENT_PARALLEL_PRE_COMMIT ||
+		 event == XACT_EVENT_PRE_COMMIT))
+	{
+		pgfdw_prepare_xacts();
+		return;
+	}
+
 	/*
 	 * Scan all connection cache entries to find open remote transactions, and
 	 * close them.
@@ -931,12 +945,18 @@ pgfdw_xact_callback(XactEvent event, void *arg)
 					break;
 				case XACT_EVENT_PARALLEL_COMMIT:
 				case XACT_EVENT_COMMIT:
+
+					if (pgfdw_commit_prepared(entry))
+						break;
 				case XACT_EVENT_PREPARE:
 					/* Pre-commit should have closed the open transaction */
 					elog(ERROR, "missed cleaning up connection during pre-commit");
 					break;
 				case XACT_EVENT_PARALLEL_ABORT:
 				case XACT_EVENT_ABORT:
+
+					if (pgfdw_rollback_prepared(entry))
+						break;
 
 					pgfdw_abort_cleanup(entry, "ABORT TRANSACTION", true);
 					break;
@@ -945,6 +965,7 @@ pgfdw_xact_callback(XactEvent event, void *arg)
 
 		/* Reset state to show we're out of a transaction */
 		entry->xact_depth = 0;
+		entry->fxid = InvalidFullTransactionId;
 
 		/*
 		 * If the connection isn't in a good idle state, it is marked as
@@ -1637,4 +1658,86 @@ disconnect_cached_connections(Oid serverid)
 	}
 
 	return result;
+}
+
+static void
+pgfdw_prepare_xacts(void)
+{
+	HASH_SEQ_STATUS scan;
+	ConnCacheEntry *entry;
+
+	hash_seq_init(&scan, ConnectionHash);
+	while ((entry = (ConnCacheEntry *) hash_seq_search(&scan)))
+	{
+		char		sql[256];
+
+		if (entry->conn == NULL || entry->xact_depth == 0)
+			continue;
+
+		pgfdw_reject_incomplete_xact_state_change(entry);
+
+		Assert(!FullTransactionIdIsValid(entry->fxid));
+		entry->fxid = GetTopFullTransactionId();
+
+		snprintf(sql, sizeof(sql),
+				 "PREPARE TRANSACTION 'pgfdw_%s_%lu_%u'",
+				 (*cluster_name == '\0') ? "null" : cluster_name,
+				 U64FromFullTransactionId(entry->fxid),
+				 (Oid) entry->key);
+
+		entry->changing_xact_state = true;
+		do_sql_command(entry->conn, sql);
+		entry->changing_xact_state = false;
+	}
+}
+
+static bool
+pgfdw_commit_prepared(ConnCacheEntry *entry)
+{
+	char		sql[256];
+	bool		success = false;
+
+	if (!FullTransactionIdIsValid(entry->fxid))
+		return false;
+
+	snprintf(sql, sizeof(sql),
+			 "COMMIT PREPARED 'pgfdw_%s_%lu_%u'",
+			 (*cluster_name == '\0') ? "null" : cluster_name,
+			 U64FromFullTransactionId(entry->fxid),
+			 (Oid) entry->key);
+
+	entry->changing_xact_state = true;
+	success = pgfdw_exec_cleanup_query(entry->conn, sql, false);
+	entry->changing_xact_state = false;
+
+	if (entry->have_prep_stmt && entry->have_error && success)
+	{
+		PGresult   *res = PQexec(entry->conn, "DEALLOCATE ALL");
+
+		PQclear(res);
+	}
+
+	entry->have_prep_stmt = false;
+	entry->have_error = false;
+	entry->fxid = InvalidFullTransactionId;
+
+	return true;
+}
+
+static bool
+pgfdw_rollback_prepared(ConnCacheEntry *entry)
+{
+	char		sql[256];
+
+	if (!FullTransactionIdIsValid(entry->fxid))
+		return false;
+
+	snprintf(sql, sizeof(sql),
+			 "ROLLBACK PREPARED 'pgfdw_%s_%lu_%u'",
+			 (*cluster_name == '\0') ? "null" : cluster_name,
+			 U64FromFullTransactionId(entry->fxid),
+			 (Oid) entry->key);
+	pgfdw_abort_cleanup(entry, sql, true);
+
+	return true;
 }

--- a/contrib/postgres_fdw/expected/postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/postgres_fdw.out
@@ -10764,3 +10764,109 @@ ERROR:  invalid value for integer option "fetch_size": 100$%$#$#
 CREATE FOREIGN TABLE inv_bsz (c1 int )
 	SERVER loopback OPTIONS (batch_size '100$%$#$#');
 ERROR:  invalid value for integer option "batch_size": 100$%$#$#
+-- ===================================================================
+-- test two phase commit
+-- ===================================================================
+SET debug_discard_caches = 0;
+ALTER SERVER loopback OPTIONS (SET application_name 'fdw_loopback');
+ALTER SERVER loopback2 OPTIONS (ADD application_name 'fdw_loopback2');
+SET postgres_fdw.two_phase_commit TO true;
+BEGIN;
+INSERT INTO "S 1"."T 3"(c1, c2) VALUES (1000901, 1000902);
+INSERT INTO ft1(c1, c2) VALUES (1000901, 1000902);
+INSERT INTO ft6(c1, c2) VALUES (1000901, 1000902);
+COMMIT;
+SELECT count(*) FROM "S 1"."T 3" WHERE c1 = 1000901;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM ft1 WHERE c1 = 1000901;
+ count 
+-------
+     1
+(1 row)
+
+SELECT count(*) FROM ft6 WHERE c1 = 1000901;
+ count 
+-------
+     1
+(1 row)
+
+SELECT * FROM pg_prepared_xacts;
+ transaction | gid | prepared | owner | database 
+-------------+-----+----------+-------+----------
+(0 rows)
+
+BEGIN;
+INSERT INTO "S 1"."T 3"(c1, c2) VALUES (1000903, 1000904);
+INSERT INTO ft1(c1, c2) VALUES (1000903, 1000904);
+INSERT INTO ft6(c1, c2) VALUES (1000903, 1000904);
+ROLLBACK;
+SELECT count(*) FROM "S 1"."T 3" WHERE c1 = 1000903;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM ft1 WHERE c1 = 1000903;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM ft6 WHERE c1 = 1000903;
+ count 
+-------
+     0
+(1 row)
+
+SELECT * FROM pg_prepared_xacts;
+ transaction | gid | prepared | owner | database 
+-------------+-----+----------+-------+----------
+(0 rows)
+
+\set SHOW_CONTEXT never
+BEGIN;
+INSERT INTO "S 1"."T 3"(c1, c2) VALUES (1000905, 1000906);
+INSERT INTO ft1(c1, c2) VALUES (1000905, 1000906);
+INSERT INTO ft6(c1, c2) VALUES (1000905, 1000906);
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+       WHERE application_name = 'fdw_loopback2';
+ pg_terminate_backend 
+----------------------
+ t
+(1 row)
+
+COMMIT;
+ERROR:  FATAL:  terminating connection due to administrator command
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+SELECT count(*) FROM "S 1"."T 3" WHERE c1 = 1000905;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM ft1 WHERE c1 = 1000905;
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM ft6 WHERE c1 = 1000905;
+ count 
+-------
+     0
+(1 row)
+
+SELECT * FROM pg_prepared_xacts;
+ transaction | gid | prepared | owner | database 
+-------------+-----+----------+-------+----------
+(0 rows)
+
+\unset SHOW_CONTEXT
+RESET postgres_fdw.two_phase_commit;
+RESET debug_discard_caches;

--- a/contrib/postgres_fdw/option.c
+++ b/contrib/postgres_fdw/option.c
@@ -49,6 +49,7 @@ static PQconninfoOption *libpq_options;
  * GUC parameters
  */
 char	   *pgfdw_application_name = NULL;
+bool		pgfdw_two_phase_commit = false;
 
 void		_PG_init(void);
 
@@ -467,4 +468,15 @@ _PG_init(void)
 							   NULL,
 							   NULL,
 							   NULL);
+
+	DefineCustomBoolVariable("postgres_fdw.two_phase_commit",
+							 "Use two phase commit to commit foreign transactions.",
+							 NULL,
+							 &pgfdw_two_phase_commit,
+							 false,
+							 PGC_USERSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
 }

--- a/contrib/postgres_fdw/postgres_fdw--1.1--1.2.sql
+++ b/contrib/postgres_fdw/postgres_fdw--1.1--1.2.sql
@@ -1,0 +1,73 @@
+/* contrib/postgres_fdw/postgres_fdw--1.1--1.2.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION postgres_fdw UPDATE TO '1.2'" to load this file. \quit
+
+CREATE TYPE foreign_prepared_xacts AS
+  (server name, transaction xid, gid text,
+    prepared timestamp with time zone, owner name, database name);
+
+CREATE TYPE resolve_foreign_prepared_xacts AS
+  (status text, server name, transaction xid, gid text,
+    prepared timestamp with time zone, owner name, database name);
+
+CREATE OR REPLACE FUNCTION pg_foreign_prepared_xacts
+  (server name, origin boolean DEFAULT false)
+  RETURNS SETOF foreign_prepared_xacts AS $$
+DECLARE
+  sql TEXT := 'SELECT * FROM pg_prepared_xacts';
+BEGIN
+  PERFORM * FROM pg_foreign_server WHERE srvname = server;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'server "%" does not exist', server;
+  END IF;
+  IF origin THEN
+    sql := sql || ' WHERE gid LIKE ''pgfdw_' ||
+      current_setting('cluster_name') || '_%_%''';
+  END IF;
+  RETURN QUERY SELECT server, * FROM
+    dblink(server, sql) AS t1
+    (transaction xid, gid text, prepared timestamp with time zone,
+      owner name, database name);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pg_foreign_prepared_xacts_all
+  (origin boolean DEFAULT false)
+  RETURNS SETOF foreign_prepared_xacts AS $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN SELECT * FROM pg_foreign_server LOOP
+    RETURN QUERY SELECT * FROM pg_foreign_prepared_xacts(r.srvname, origin);
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pg_resolve_foreign_prepared_xacts_all()
+  RETURNS SETOF resolve_foreign_prepared_xacts AS $$
+DECLARE
+  r resolve_foreign_prepared_xacts;
+  sql TEXT;
+  status TEXT;
+BEGIN
+  FOR r IN SELECT NULL AS status, * FROM pg_foreign_prepared_xacts_all(true)
+  LOOP
+    sql := NULL;
+    BEGIN
+      r.status := pg_xact_status(split_part(r.gid, '_', 3)::xid8);
+      CASE r.status
+        WHEN 'committed' THEN
+          sql := 'COMMIT PREPARED ''' || r.gid || '''';
+        WHEN 'aborted' THEN
+          sql := 'ROLLBACK PREPARED ''' || r.gid || '''';
+      END CASE;
+    EXCEPTION WHEN OTHERS THEN
+    END;
+    IF sql IS NOT NULL THEN
+      RETURN NEXT r;
+      PERFORM dblink(r.server, sql);
+    END IF;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;

--- a/contrib/postgres_fdw/postgres_fdw--1.1--1.2.sql
+++ b/contrib/postgres_fdw/postgres_fdw--1.1--1.2.sql
@@ -19,7 +19,7 @@ BEGIN
   END IF;
   sql := 'SELECT * FROM pg_prepared_xacts ' ||
     'WHERE owner = current_user AND database = current_database() ' ||
-    'AND gid LIKE ''pgfdw_' || current_setting('cluster_name') || '_%_%''';
+    'AND gid LIKE ''pgfdw_%_%_' || current_setting('cluster_name') || '''';
   RETURN QUERY SELECT * FROM
     dblink(server, sql) AS t1
     (transaction xid, gid text, prepared timestamp with time zone,
@@ -38,7 +38,7 @@ BEGIN
     FROM pg_foreign_prepared_xacts(server) LOOP
     sql := NULL;
     BEGIN
-      r.status := pg_xact_status(split_part(r.gid, '_', 3)::xid8);
+      r.status := pg_xact_status(split_part(r.gid, '_', 2)::xid8);
       CASE r.status
         WHEN 'committed' THEN
           sql := 'COMMIT PREPARED ''' || r.gid || '''';

--- a/contrib/postgres_fdw/postgres_fdw--1.1--1.2.sql
+++ b/contrib/postgres_fdw/postgres_fdw--1.1--1.2.sql
@@ -3,56 +3,39 @@
 -- complain if script is sourced in psql, rather than via ALTER EXTENSION
 \echo Use "ALTER EXTENSION postgres_fdw UPDATE TO '1.2'" to load this file. \quit
 
-CREATE TYPE foreign_prepared_xacts AS
-  (server name, transaction xid, gid text,
-    prepared timestamp with time zone, owner name, database name);
-
 CREATE TYPE resolve_foreign_prepared_xacts AS
   (status text, server name, transaction xid, gid text,
     prepared timestamp with time zone, owner name, database name);
 
-CREATE OR REPLACE FUNCTION pg_foreign_prepared_xacts
-  (server name, origin boolean DEFAULT false)
-  RETURNS SETOF foreign_prepared_xacts AS $$
+CREATE OR REPLACE FUNCTION
+  pg_foreign_prepared_xacts (server name)
+  RETURNS SETOF pg_prepared_xacts AS $$
 DECLARE
-  sql TEXT := 'SELECT * FROM pg_prepared_xacts';
+  sql TEXT;
 BEGIN
   PERFORM * FROM pg_foreign_server WHERE srvname = server;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'server "%" does not exist', server;
   END IF;
-  IF origin THEN
-    sql := sql || ' WHERE gid LIKE ''pgfdw_' ||
-      current_setting('cluster_name') || '_%_%''';
-  END IF;
-  RETURN QUERY SELECT server, * FROM
+  sql := 'SELECT * FROM pg_prepared_xacts ' ||
+    'WHERE owner = current_user AND database = current_database() ' ||
+    'AND gid LIKE ''pgfdw_' || current_setting('cluster_name') || '_%_%''';
+  RETURN QUERY SELECT * FROM
     dblink(server, sql) AS t1
     (transaction xid, gid text, prepared timestamp with time zone,
       owner name, database name);
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_foreign_prepared_xacts_all
-  (origin boolean DEFAULT false)
-  RETURNS SETOF foreign_prepared_xacts AS $$
-DECLARE
-  r RECORD;
-BEGIN
-  FOR r IN SELECT * FROM pg_foreign_server LOOP
-    RETURN QUERY SELECT * FROM pg_foreign_prepared_xacts(r.srvname, origin);
-  END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION pg_resolve_foreign_prepared_xacts_all()
+CREATE OR REPLACE FUNCTION
+  pg_resolve_foreign_prepared_xacts (server name)
   RETURNS SETOF resolve_foreign_prepared_xacts AS $$
 DECLARE
   r resolve_foreign_prepared_xacts;
   sql TEXT;
-  status TEXT;
 BEGIN
-  FOR r IN SELECT NULL AS status, * FROM pg_foreign_prepared_xacts_all(true)
-  LOOP
+  FOR r IN SELECT NULL AS status, server, *
+    FROM pg_foreign_prepared_xacts(server) LOOP
     sql := NULL;
     BEGIN
       r.status := pg_xact_status(split_part(r.gid, '_', 3)::xid8);
@@ -66,8 +49,20 @@ BEGIN
     END;
     IF sql IS NOT NULL THEN
       RETURN NEXT r;
-      PERFORM dblink(r.server, sql);
+      PERFORM dblink(server, sql);
     END IF;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION
+  pg_resolve_foreign_prepared_xacts_all()
+  RETURNS SETOF resolve_foreign_prepared_xacts AS $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN SELECT * FROM pg_foreign_server LOOP
+    RETURN QUERY SELECT * FROM pg_resolve_foreign_prepared_xacts(r.srvname);
   END LOOP;
 END;
 $$ LANGUAGE plpgsql;

--- a/contrib/postgres_fdw/postgres_fdw.control
+++ b/contrib/postgres_fdw/postgres_fdw.control
@@ -1,5 +1,5 @@
 # postgres_fdw extension
 comment = 'foreign-data wrapper for remote PostgreSQL servers'
-default_version = '1.1'
+default_version = '1.2'
 module_pathname = '$libdir/postgres_fdw'
 relocatable = true

--- a/contrib/postgres_fdw/postgres_fdw.h
+++ b/contrib/postgres_fdw/postgres_fdw.h
@@ -159,6 +159,7 @@ extern int	ExtractConnectionOptions(List *defelems,
 extern List *ExtractExtensionList(const char *extensionsString,
 								  bool warnOnMissing);
 extern char *pgfdw_application_name;
+extern bool pgfdw_two_phase_commit;
 
 /* in deparse.c */
 extern void classifyConditions(PlannerInfo *root,

--- a/contrib/postgres_fdw/t/001_test_two_phase_commit.pl
+++ b/contrib/postgres_fdw/t/001_test_two_phase_commit.pl
@@ -171,7 +171,7 @@ sub test_if_two_phase_commit_used
 	my $txid_current = $node_master->safe_psql('postgres', qq(
 	SELECT txid_current();
 	));
-	$txid_current++;  # next txid
+	$txid_current++;  # prepared transaction id must have next txid
 	
 	# Execute the sql query
 	$node_master->safe_psql('postgres', $sql);

--- a/contrib/postgres_fdw/t/001_test_two_phase_commit.pl
+++ b/contrib/postgres_fdw/t/001_test_two_phase_commit.pl
@@ -1,0 +1,205 @@
+# Tests for two phase commit
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More tests => 6;
+
+# Setup a coordinator node
+my $node_master = PostgresNode->new("master");
+$node_master->init(allows_streaming => 1);
+$node_master->append_conf('postgresql.conf', qq(
+postgres_fdw.two_phase_commit = true
+log_statement = 'all'
+synchronous_standby_names ='*'
+));
+$node_master->start;
+
+# Setup a standby node for coordinator
+my $node_standby = PostgresNode->new("standby");
+my $backup_name = 'master_backup';
+$node_master->backup($backup_name);
+$node_standby->init_from_backup($node_master, $backup_name,
+							   has_streaming => 1);
+$node_standby->start;
+$node_master->reload;
+
+# Set up foreign nodes
+my @foreign_nodes = setup_foreign_nodes(3);
+
+# Prepare remote accesses
+$node_master->safe_psql('postgres', qq(
+CREATE EXTENSION postgres_fdw
+));
+foreach my $f_node (@foreign_nodes)
+{
+	my $tbl_name = $f_node->name;
+	my $srv_name = $f_node->name;
+	my $port = $f_node->port;
+
+	# Create a foreign server object
+	$node_master->safe_psql('postgres', qq(
+	CREATE SERVER $srv_name FOREIGN DATA WRAPPER postgres_fdw
+	OPTIONS (dbname 'postgres', port '$port');
+	));
+	
+	# Create a user mapping
+	$node_master->safe_psql('postgres', qq(
+	CREATE USER MAPPING FOR CURRENT_USER SERVER $srv_name;
+	));
+
+	# Create a foreign table
+	$f_node->safe_psql('postgres', qq(
+	CREATE SCHEMA fs;
+	CREATE TABLE fs.$tbl_name (c int);
+	));
+	$node_master->safe_psql('postgres', qq(
+	IMPORT FOREIGN SCHEMA fs FROM SERVER $srv_name INTO public;
+	));
+}
+
+# Create a local table
+$node_master->safe_psql('postgres', qq(
+CREATE TABLE l_table (c int);
+));
+
+# Check current values for tests
+my $txid_current = $node_master->safe_psql('postgres', qq(
+SELECT txid_current();
+));
+my @foreign_server_oids;
+foreach my $f_node (@foreign_nodes)
+{
+	my $srv_name = $f_node->name;
+	my $srv_oid = $node_master->safe_psql('postgres', qq(
+	SELECT oid FROM pg_foreign_server WHERE srvname = '$srv_name';
+	));
+	push @foreign_server_oids, $srv_oid;
+}
+
+# Test patterns
+my $tbl1 = $foreign_nodes[0]->name;
+my $tbl2 = $foreign_nodes[1]->name;
+my $tbl3 = $foreign_nodes[2]->name;
+
+# Insert all foreign tables
+test_if_two_phase_commit_used(qq(
+BEGIN;
+INSERT INTO $tbl1 VALUES (1);
+INSERT INTO $tbl2 VALUES (1);
+INSERT INTO $tbl3 VALUES (1);
+COMMIT;
+), ("true", "true", "true"));
+
+# Insert all foreign tables and execute select queries
+test_if_two_phase_commit_used(qq(
+BEGIN;
+INSERT INTO $tbl1 VALUES (1);
+SELECT * FROM $tbl1;
+INSERT INTO $tbl2 VALUES (1);
+SELECT * FROM $tbl2;
+INSERT INTO $tbl3 VALUES (1);
+SELECT * FROM $tbl3;
+COMMIT;
+), ("true", "true", "true"));
+
+## Insert two foreign tables
+#test_if_two_phase_commit_used(qq(
+#BEGIN;
+#INSERT INTO $tbl1 VALUES (1);
+#INSERT INTO $tbl2 VALUES (1);
+#COMMIT;
+#), ("true", "true", "false"));
+#
+## Insert local table and a foregin table
+#test_two_phase_commit_used(qq(
+#BEGIN;
+#INSERT INTO $tbl1 VALUES (1);
+#INSERT INTO l_table VALUES (1);
+#COMMIT;
+#), ("true", "false", "false"));
+#
+## Only Select queries are executed on foreign tables
+#test_two_phase_commit_used(qq(
+#BEGIN;
+#SELECT * FROM $tbl1;
+#SELECT * FROM $tbl2;
+#SELECT * FROM $tbl3;
+#COMMIT;
+#), ("false", "false", "false"));
+#
+## Only a insert query is executed on foreign tables
+#test_two_phase_commit_used(qq(
+#BEGIN;
+#INSERT INTO $tbl1 VALUES (1);
+#COMMIT;
+#), ("false", "false", "false"));
+
+
+# Initialize foreign nodes
+sub setup_foreign_nodes
+{
+	my ($num) = @_;
+	
+	my @nodes;
+	foreach my $i (1..$num)
+	{
+		my $node = new_foreign_node("fs$i");
+		push @nodes, $node;
+	}
+	return @nodes;
+}
+
+# Initialize a foreign node
+sub new_foreign_node
+{
+	my ($name) = @_;
+
+	my $node = PostgresNode->new($name);
+	$node->init;
+	$node->append_conf('postgresql.conf', qq(
+	log_statement = 'all'
+	max_prepared_transactions = 10
+	));
+	$node->start;
+
+	return $node;
+}
+
+# Verify that two phase commit is used or not
+sub test_if_two_phase_commit_used
+{
+	my ($sql, @used) = @_;
+	
+	# Execute the sql query
+	$node_master->safe_psql('postgres', $sql);
+
+	# Prepare to verify
+	my $cluster_name = $node_master->name;  # cluster name is configured to the argument of PostgresNode->new()
+	$txid_current++;
+	
+	# Verify for each node using its log
+	while (my ($i, $f_node) = each(@foreign_nodes))
+	{
+		my $f_srv_oid = ${foreign_server_oids[$i]};
+		my $f_node_log = slurp_file($f_node->logfile());
+		my $prepare_txid = "'pgfdw_${txid_current}_${f_srv_oid}_${cluster_name}'";
+
+		if ($used[$i] eq 'true')
+		{
+			like(
+				$f_node_log,
+				qr/COMMIT PREPARED/,
+				$prepare_txid
+			);
+		}
+		else
+		{
+			unlike(
+				$f_node_log,
+				qr/COMMIT PREPARED/,
+				$prepare_txid
+			);
+		}
+	}
+} 


### PR DESCRIPTION
Hi, 

I'm Masahiro Ikeda. 

Thanks for developing two-phase commits for postgres_fdw.
I'd like to add tap tests for them for reliability.

I made a PoC patch for it. Please check it if you have any time.

The test_if_two_phase_commit_used() is the main logic to test.
It confirms the server log with log_statements = 'all', and checks 
whether the two-phase commit is selected or not per each node.

Since some tests don't work, I comment them out.
If it's better, I'll remove them.

Now, 6 tests are passed,

```
> cd contrib/postgres_fdw 
> make check PROVE_TESTS='t/001_test_two_phase_commit.pl'  
============== removing existing temp instance        ==============
============== creating temporary instance            ==============
============== initializing database system           ==============
============== starting postmaster                    ==============
running on port 51696 with PID 598391
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test postgres_fdw                 ... ok         5047 ms
============== shutting down postmaster               ==============
============== removing temporary instance            ==============

=====================
 All 1 tests passed.
=====================

rm -rf '/home/ikeda/repos/psql/master/postgresql-master/contrib/postgres_fdw'/tmp_check
/bin/mkdir -p '/home/ikeda/repos/psql/master/postgresql-master/contrib/postgres_fdw'/tmp_check
cd . && TESTDIR='/home/ikeda/repos/psql/master/postgresql-master/contrib/postgres_fdw' PATH="/home/ikeda/repos/psql/master/postgresql-master/tmp_install/home/ikeda/repos/psql/master/bin:$PATH" LD_LIBRARY_PATH="/home/ikeda/repos/psql/master/postgresql-master/tmp_install/home/ikeda/repos/psql/master/lib:$LD_LIBRARY_PATH"  PGPORT='65432' PG_REGRESS='/home/ikeda/repos/psql/master/postgresql-master/contrib/postgres_fdw/../../src/test/regress/pg_regress' /bin/prove -I ../../src/test/perl/ -I .  t/001_test_two_phase_commit.pl
t/001_test_two_phase_commit.pl .. ok
All tests successful.
Files=1, Tests=6,  8 wallclock secs ( 0.02 usr  0.00 sys +  5.75 cusr  1.49 csys =  7.26 CPU)
Result: PASS
```

Best Regards,